### PR TITLE
fix: resolve bash syntax error in production workflow

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -273,8 +273,8 @@ jobs:
               sleep $((2**i))
             fi
           done
-            echo "✅ Updated production manifests with version $VERSION"
-          fi
+          
+          echo "✅ Updated production manifests with version $VERSION"
 
   # Summary
   release-summary:


### PR DESCRIPTION
Fixed malformed conditional block that was causing 'unexpected token fi' error. The workflow functionality was working correctly, just had a syntax issue at the end.